### PR TITLE
Add tags view

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,9 @@ twitter_username: joewiz
 github_username:  joewiz
 google_analytics: UA-582491-4
 timezone: America/New_York
+header_pages:
+  - tags.md
+  - about.md
 
 # Build settings
 host: "0.0.0.0" # bind to all interfaces so dev container port forwarding works

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,7 +16,11 @@ layout: default
       </time>
       {%- if page.author -%}
         • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>
-      {%- endif -%}</p>
+      {%- endif -%}
+      {%- if page.tags.size > 0 -%}
+        • {% for tag in page.tags %}<a href="/tag/{{ tag | replace: ' ', '-' }}/">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}
+      {%- endif -%}
+    </p>
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">

--- a/_layouts/tagpage.html
+++ b/_layouts/tagpage.html
@@ -1,0 +1,24 @@
+---
+layout: default
+---
+<article class="post">
+
+  <header class="post-header">
+    <h1 class="post-title">{{ page.title | escape }}</h1>
+  </header>
+
+  <div class="post-content">
+    <p><a href="/tags/">← All tags</a></p>
+    <ul>
+      {% for post in site.posts %}
+        {% if post.tags contains page.tag %}
+          <li>
+            <a href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+            <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </div>
+
+</article>

--- a/_posts/2010-11-22-why-exist-should-be-in-every-digital-humanists-toolkit.md
+++ b/_posts/2010-11-22-why-exist-should-be-in-every-digital-humanists-toolkit.md
@@ -7,7 +7,7 @@ tags:
   - xml
   - xquery
   - dh
-  - exist
+  - exist-db
 date: 2010-11-22 16:15:00-0400
 ---
 

--- a/_posts/2012-02-06-an-under-appreciated-use-for-xquery-wrangling-plain-text.md
+++ b/_posts/2012-02-06-an-under-appreciated-use-for-xquery-wrangling-plain-text.md
@@ -6,7 +6,7 @@ title: |
 tags: 
   - tei
   - xquery
-  - exist
+  - exist-db
 date: 2012-02-06 16:15:00-0400
 ---
 

--- a/_posts/2012-04-07-upside-down.md
+++ b/_posts/2012-04-07-upside-down.md
@@ -4,9 +4,10 @@ title: Upside down
 tags:
   - xml
   - xquery
-  - existdb
+  - exist-db
   - dhoxss
 link: http://depalaeographia.tumblr.com/post/9120075588/upside-down
+
 ---
 depalaeographia:
 

--- a/_posts/2013-07-03-trimming-text-without-cutting-off-words-using-xquery.md
+++ b/_posts/2013-07-03-trimming-text-without-cutting-off-words-using-xquery.md
@@ -2,8 +2,9 @@
 layout: post
 title: Trimming text without cutting off words, using XQuery
 tags:
-  - XQuery
+  - xquery
 link: https://gist.github.com/joewiz/5923408
+
 ---
 A new Github gist:
 

--- a/_posts/2013-07-04-living-in-an-oauth-json-world.md
+++ b/_posts/2013-07-04-living-in-an-oauth-json-world.md
@@ -2,16 +2,17 @@
 layout: post
 title: Living in an OAuth & JSON World
 tags:
-  - xquery 
-  - oauth 
-  - apis 
-  - json 
-  - expath 
-  - gov20 
-  - twitter 
-  - socialmedia 
-  - existdb 
+  - xquery
+  - oauth
+  - api
+  - json
+  - expath
+  - gov20
+  - twitter
+  - socialmedia
+  - exist-db
   - opensource
+
 ---
 
 Another day, [another gist](http://gist.github.com/joewiz/5929809). Today's was prompted by [a question on the eXist-db mailing list](http://markmail.org/thread/5izhua45glftmxja) about how to access OAuth-based services like the Google API with XQuery. I happened to have just been working on accessing the OAuth-based Twitter v1.1 API for the new social media section of [my office's homepage](http://history.state.gov), so I [posted the code](http://gist.github.com/joewiz/5929809) and [some pointers](https://gist.github.com/joewiz/5929809#comment-856692). Like the gist I posted [yesterday](http://joewiz.tumblr.com/post/54546474105/trimming-text-without-cutting-off-words-using-xquery), I hope others can use these bits of XQuery code.

--- a/_posts/2014-02-13-filling-pdf-forms-with-pdftk-xfdf-and-xquery.md
+++ b/_posts/2014-02-13-filling-pdf-forms-with-pdftk-xfdf-and-xquery.md
@@ -2,12 +2,13 @@
 published: true
 layout: post
 title: Filling PDF forms with PDFtk, XFDF, and XQuery
-tags: 
-  - XQuery
-  - eXist-db
-  - PDF
-  - PDFtk
-  - XFDF
+tags:
+  - xquery
+  - exist-db
+  - pdf
+  - pdftk
+  - xfdf
+
 ---
 
 It's hard to believe that PDF is still used for forms these days; they seem so last decade, or even century, compared to what's possible on the web. I dread the tedium and boredom of filling out a PDF form with tons of fields or creating multiple editions of a form with different information on each. 

--- a/_posts/2014-12-28-exist-the-indispensable-guide.md
+++ b/_posts/2014-12-28-exist-the-indispensable-guide.md
@@ -3,8 +3,8 @@ published: true
 layout: post
 title: | 
     eXist: the indispensable guide
-tags: 
-  - exist
+tags:
+  - exist-db
   - xquery
 date: 2014-12-28 08:30:00-0500
 ---

--- a/_posts/2015-01-18-a-preview-of-xquery-3.1s-json-support-in-exist.md
+++ b/_posts/2015-01-18-a-preview-of-xquery-3.1s-json-support-in-exist.md
@@ -3,8 +3,8 @@ published: true
 layout: post
 title: | 
     A preview of XQuery 3.1's JSON support in eXist
-tags: 
-  - exist
+tags:
+  - exist-db
   - xquery
   - json
   - api

--- a/tag/api.md
+++ b/tag/api.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: api"
+tag: api
+permalink: /tag/api/
+---

--- a/tag/bookmarklet.md
+++ b/tag/bookmarklet.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: bookmarklet"
+tag: bookmarklet
+permalink: /tag/bookmarklet/
+---

--- a/tag/chrome.md
+++ b/tag/chrome.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: chrome"
+tag: chrome
+permalink: /tag/chrome/
+---

--- a/tag/dh.md
+++ b/tag/dh.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: dh"
+tag: dh
+permalink: /tag/dh/
+---

--- a/tag/dhoxss.md
+++ b/tag/dhoxss.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: dhoxss"
+tag: dhoxss
+permalink: /tag/dhoxss/
+---

--- a/tag/exist-db.md
+++ b/tag/exist-db.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: exist-db"
+tag: exist-db
+permalink: /tag/exist-db/
+---

--- a/tag/expath.md
+++ b/tag/expath.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: expath"
+tag: expath
+permalink: /tag/expath/
+---

--- a/tag/github.md
+++ b/tag/github.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: github"
+tag: github
+permalink: /tag/github/
+---

--- a/tag/gov20.md
+++ b/tag/gov20.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: gov20"
+tag: gov20
+permalink: /tag/gov20/
+---

--- a/tag/jekyll.md
+++ b/tag/jekyll.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: jekyll"
+tag: jekyll
+permalink: /tag/jekyll/
+---

--- a/tag/json.md
+++ b/tag/json.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: json"
+tag: json
+permalink: /tag/json/
+---

--- a/tag/learning.md
+++ b/tag/learning.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: learning"
+tag: learning
+permalink: /tag/learning/
+---

--- a/tag/nlp.md
+++ b/tag/nlp.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: nlp"
+tag: nlp
+permalink: /tag/nlp/
+---

--- a/tag/oauth.md
+++ b/tag/oauth.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: oauth"
+tag: oauth
+permalink: /tag/oauth/
+---

--- a/tag/opensource.md
+++ b/tag/opensource.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: opensource"
+tag: opensource
+permalink: /tag/opensource/
+---

--- a/tag/pdf.md
+++ b/tag/pdf.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: pdf"
+tag: pdf
+permalink: /tag/pdf/
+---

--- a/tag/pdftk.md
+++ b/tag/pdftk.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: pdftk"
+tag: pdftk
+permalink: /tag/pdftk/
+---

--- a/tag/search.md
+++ b/tag/search.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: search"
+tag: search
+permalink: /tag/search/
+---

--- a/tag/socialmedia.md
+++ b/tag/socialmedia.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: socialmedia"
+tag: socialmedia
+permalink: /tag/socialmedia/
+---

--- a/tag/tei.md
+++ b/tag/tei.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: tei"
+tag: tei
+permalink: /tag/tei/
+---

--- a/tag/text-mining.md
+++ b/tag/text-mining.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: text mining"
+tag: text mining
+permalink: /tag/text-mining/
+---

--- a/tag/tumblr.md
+++ b/tag/tumblr.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: tumblr"
+tag: tumblr
+permalink: /tag/tumblr/
+---

--- a/tag/twitter.md
+++ b/tag/twitter.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: twitter"
+tag: twitter
+permalink: /tag/twitter/
+---

--- a/tag/writing.md
+++ b/tag/writing.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: writing"
+tag: writing
+permalink: /tag/writing/
+---

--- a/tag/xfdf.md
+++ b/tag/xfdf.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: xfdf"
+tag: xfdf
+permalink: /tag/xfdf/
+---

--- a/tag/xml.md
+++ b/tag/xml.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: xml"
+tag: xml
+permalink: /tag/xml/
+---

--- a/tag/xquery.md
+++ b/tag/xquery.md
@@ -1,0 +1,6 @@
+---
+layout: tagpage
+title: "Tag: xquery"
+tag: xquery
+permalink: /tag/xquery/
+---

--- a/tags.md
+++ b/tags.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Tags
+permalink: /tags/
+---
+
+{% assign sorted_tags = site.tags | sort %}
+<ul>
+  {% for tag in sorted_tags %}
+    <li><a href="/tag/{{ tag[0] | replace: ' ', '-' }}/">{{ tag[0] }}</a> ({{ tag[1].size }})</li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
Closes #3

## Summary
- Normalize tags across all posts (lowercase, no trailing spaces, `exist-db` convention)
- Add `_layouts/tagpage.html` listing posts per tag
- Add 27 individual tag pages at `/tag/<tag>/`
- Add `/tags/` index listing all tags alphabetically with post counts
- Add tag links to post metadata line
- Add Tags to site nav

## Test plan
- [x] A post page shows tag links in the metadata
- [x] `/tags/` lists all tags with counts
- [x] `/tag/xquery/` lists all xquery posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)