### PR TITLE
Switch from Universal Analytics to GA4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://joewiz.org" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: joewiz
 github_username:  joewiz
-google_analytics: UA-582491-4
+google_analytics: G-QGZ2VS82PJ
 timezone: America/New_York
 header_pages:
   - tags.md

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,0 +1,9 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  if (!(window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1")) {
+    gtag('js', new Date());
+    gtag('config', '{{ site.google_analytics }}');
+  }
+</script>


### PR DESCRIPTION
Update google_analytics in _config.yml from the defunct UA-582491-4 (Universal Analytics, shut down July 2023) to G-QGZ2VS82PJ (GA4).

Add _includes/google-analytics.html to override Minima 2.5.x's built-in analytics snippet, which uses the legacy analytics.js API and is incompatible with GA4. The replacement uses the modern gtag.js and preserves the Do Not Track check from the original Minima template.

Closes #31

https://claude.ai/code/session_01BcPqE3S2tcE7uheDB58hNu